### PR TITLE
Fix be crash caused by #3912 and #3825 (#3934) (#4054)

### DIFF
--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -123,13 +123,6 @@ bool operator==(const Aws::Client::ClientConfiguration& lhs, const Aws::Client::
 
 class S3ClientFactory {
 public:
-    // We cached config here and make a deep copy each time.Since aws sdk has changed the
-    // Aws::Client::ClientConfiguration default constructor to search for the region
-    // (where as before 1.8 it has been hard coded default of "us-east-1").
-    // Part of that change is looking through the ec2 metadata, which can take a long time.
-    // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
-    static Aws::Client::ClientConfiguration s_config;
-
     using ClientConfiguration = Aws::Client::ClientConfiguration;
     using S3Client = Aws::S3::S3Client;
     using S3ClientPtr = std::shared_ptr<S3Client>;
@@ -148,6 +141,16 @@ public:
 
     S3ClientPtr new_client(const ClientConfiguration& config);
 
+    static ClientConfiguration& getClientConfig() {
+        // We cached config here and make a deep copy each time.Since aws sdk has changed the
+        // Aws::Client::ClientConfiguration default constructor to search for the region
+        // (where as before 1.8 it has been hard coded default of "us-east-1").
+        // Part of that change is looking through the ec2 metadata, which can take a long time.
+        // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
+        static ClientConfiguration instance;
+        return instance;
+    }
+
 private:
     S3ClientFactory();
 
@@ -160,8 +163,6 @@ private:
     S3ClientPtr _clients[kMaxItems];
     Random _rand;
 };
-
-Aws::Client::ClientConfiguration S3ClientFactory::s_config;
 
 S3ClientFactory::S3ClientFactory() : _items(0), _rand((int)::time(NULL)) {}
 
@@ -196,7 +197,7 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
 }
 
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
-    Aws::Client::ClientConfiguration config = S3ClientFactory::s_config;
+    Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
     config.scheme = Aws::Http::Scheme::HTTP; // TODO: use the scheme in uri
     if (!uri.endpoint().empty()) {
         config.endpointOverride = uri.endpoint();


### PR DESCRIPTION
* be will crash with #3912 since we should init config after 
```
Aws::SDKOptions aws_sdk_options;  Aws::InitAPI(aws_sdk_options); 
```
being called. we have called the two apis in starrocks_main.cpp, so we use lazy singleton instance for AWS ClientConfiguration to avoid be crash during starting
* iceberg table has no partitions, after #3825 be will crash when we query iceberg table.We should check has_partition in _find_and_insert_hdfs_file and _init_partition_values_map

Co-authored-by: zhoukang <zhoukang199191@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
